### PR TITLE
Implemented PlayerSwapHandItemsListener

### DIFF
--- a/src/main/java/me/kyllian/captcha/CaptchaPlugin.java
+++ b/src/main/java/me/kyllian/captcha/CaptchaPlugin.java
@@ -57,6 +57,7 @@ public class CaptchaPlugin extends JavaPlugin {
         new PlayerJoinListener(this);
         new PlayerMoveListener(this);
         new PlayerQuitListener(this);
+        new PlayerSwapHandItemsListener(this);
 
     }
 

--- a/src/main/java/me/kyllian/captcha/listeners/PlayerSwapHandItemsListener.java
+++ b/src/main/java/me/kyllian/captcha/listeners/PlayerSwapHandItemsListener.java
@@ -1,0 +1,27 @@
+package me.kyllian.captcha.listeners;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+
+import me.kyllian.captcha.CaptchaPlugin;
+import me.kyllian.captcha.player.PlayerData;
+
+public class PlayerSwapHandItemsListener implements Listener {
+
+	private CaptchaPlugin plugin;
+	
+	public PlayerSwapHandItemsListener(CaptchaPlugin plugin) {
+		this.plugin = plugin;
+		Bukkit.getPluginManager().registerEvents(this, plugin);
+	}
+	
+	@EventHandler
+	public void onPlayerSwapHandItems(PlayerSwapHandItemsEvent event) {
+		Player player = event.getPlayer();
+		PlayerData playerData = plugin.getPlayerDataHandler().getPlayerDataFromPlayer(player);
+		if (playerData.hasAssignedCaptcha()) event.setCancelled(true);
+	}
+}


### PR DESCRIPTION
Players are able to use the swap hand item feature to break the captcha.

To reproduce (prior to this patch): Join the server, getting a captcha. Press your hotkey to swap items in your hands. Solve the captcha. You will still not be able to move or interact with anything, but the plugin will tell you the captcha has been solved. Dropping the captcha in your hand will give you the same one back.